### PR TITLE
Change string inputs/outputs to Path/Bufs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Changed
+- [PR#5](https://github.com/EmbarkStudios/nfd2/pull/5) changed the API to take `Path` inputs and give `PathBuf` outputs for all filesystem paths.
+
 ## [0.1.1] - 2020-03-19
 ### Fixed
 - Fixed up cargo metadata


### PR DESCRIPTION
While the underlying C library only supports utf-8 strings, the API has been changed to use the more idiomatic `Path` and `PathBuf` types for working with the file system.

Resolves: #4