### PR TITLE
Implementing the Error trait on NFDError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::{ffi, fmt, str};
+use std::{error, ffi, fmt, str};
 
 #[derive(Debug)]
 pub enum NFDError {
@@ -28,3 +28,5 @@ impl From<str::Utf8Error> for NFDError {
         Self::Utf8Error(err)
     }
 }
+
+impl error::Error for NFDError {}


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Added an implementation of `std::error::Error` for `NFDError`. Used `error::Error` instead of just importing `Error` because I noticed that the rest of the file used a similar convention. 

Thanks for maintaining this crate! Please release a new version once this is merged. :)

### Related Issues

Fixes #7 
