### PR TITLE
Added Clone & PartialEq traits to Response.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ use std::{
 /// Result of opening a file dialog. Note that the underlying C library only
 /// ever returns paths encoded as utf-8 strings, if a path cannot be converted
 /// to a valid utf-8 string, then an error is returned instead.
+#[derive(Clone, PartialEq)]
 pub enum Response {
     /// The user pressed okay, and a single path was selected
     Okay(PathBuf),


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Added `Clone` & `PartialEq` traits to `Response` enum.
I need to be able to compare against a `Response` directly (w/o using a `match`). As in:
```rust
if Response::Cancel != result {
    ...
}
```
This requires only `PartialEq`.
I added `Clone` just because. For the same reason no one though `PartialEq` was needed here `Clone` may be needed by someone in a situation no one though about. :)