### PR TITLE
fix FreeBSD support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -80,7 +80,23 @@ fn main() {
 
         // The libs needed are the not in the default search-path on FreeBSD
         #[cfg(target_os = "freebsd")]
-        println!("cargo:rustc-link-search=/usr/local/lib");
+        {
+            let pkg_search = Command::new("pkg-config")
+                .arg("--libs-only-L")
+                .arg("gtk+-3.0")
+                .arg("glib-2.0")
+                .output();
+
+            if let Ok(output) = pkg_search {
+                let t = String::from_utf8(output.stdout).unwrap();
+                let flags = t.split(' ');
+                for flag in flags {
+                    if let Some(dir) = flag.strip_prefix("-L") {
+                        println!("cargo:rustc-link-search={}", dir);
+                    }
+                }
+            }
+        }
 
         println!("cargo:rustc-link-lib=gdk-3");
         println!("cargo:rustc-link-lib=gtk-3");

--- a/build.rs
+++ b/build.rs
@@ -77,6 +77,11 @@ fn main() {
         }
 
         cfg.file(nfd!("nfd_gtk.c")).compile("libnfd.a");
+
+        // The libs needed are the not in the default search-path on FreeBSD
+        #[cfg(target_os = "freebsd")]
+        println!("cargo:rustc-link-search=/usr/local/lib");
+
         println!("cargo:rustc-link-lib=gdk-3");
         println!("cargo:rustc-link-lib=gtk-3");
         println!("cargo:rustc-link-lib=glib-2.0");


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

The libraries needed for FreeBSD support are not in the default
search-path on the system, this patch adds /usr/local/lib to rustc's
search path on FreeBSD.

### Related Issues

List related issues here
