### PR TITLE
Cleanup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "nativefiledialog"]
 	path = nativefiledialog
 	url = https://github.com/mlabbe/nativefiledialog
-	branch = master
+	branch = devel

--- a/build.rs
+++ b/build.rs
@@ -70,7 +70,7 @@ fn main() {
             let t = String::from_utf8(output.stdout).unwrap();
             let flags = t.split(' ');
             for flag in flags {
-                if flag != "\n" && flag != "" {
+                if flag != "\n" && !flag.is_empty() {
                     cfg.flag(flag);
                 }
             }

--- a/build.rs
+++ b/build.rs
@@ -50,6 +50,7 @@ fn main() {
     } else if target.contains("windows") {
         cfg.cpp(true)
             .define("_CRT_SECURE_NO_WARNINGS", None)
+            .define("UNICODE", None)
             .file(nfd!("nfd_win.cpp"))
             .compile("libnfd.a");
 

--- a/build.rs
+++ b/build.rs
@@ -51,6 +51,7 @@ fn main() {
         cfg.cpp(true)
             .define("_CRT_SECURE_NO_WARNINGS", None)
             .define("UNICODE", None)
+            .define("_UNICODE", None)
             .file(nfd!("nfd_win.cpp"))
             .compile("libnfd.a");
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,13 @@
 use std::{error, ffi, fmt, str};
 
 #[derive(Debug)]
-pub enum NFDError {
+pub enum NfdError {
     NulError(ffi::NulError),
     Utf8Error(str::Utf8Error),
     Error(String),
 }
 
-impl fmt::Display for NFDError {
+impl fmt::Display for NfdError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Self::NulError(ref err) => err.fmt(f),
@@ -17,16 +17,16 @@ impl fmt::Display for NFDError {
     }
 }
 
-impl From<ffi::NulError> for NFDError {
+impl From<ffi::NulError> for NfdError {
     fn from(err: ffi::NulError) -> Self {
         Self::NulError(err)
     }
 }
 
-impl From<str::Utf8Error> for NFDError {
+impl From<str::Utf8Error> for NfdError {
     fn from(err: str::Utf8Error) -> Self {
         Self::Utf8Error(err)
     }
 }
 
-impl error::Error for NFDError {}
+impl error::Error for NfdError {}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -52,9 +52,9 @@ impl Default for nfdpathset_t {
 #[repr(u32)]
 #[derive(Debug)]
 pub enum nfdresult_t {
-    NFD_ERROR = 0,
-    NFD_OKAY = 1,
-    NFD_CANCEL = 2,
+    Error = 0,
+    Okay = 1,
+    Cancel = 2,
 }
 
 extern "C" {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -81,4 +81,5 @@ extern "C" {
     pub fn NFD_PathSet_GetCount(pathSet: *const nfdpathset_t) -> size_t;
     pub fn NFD_PathSet_GetPath(pathSet: *const nfdpathset_t, index: size_t) -> *mut nfdchar_t;
     pub fn NFD_PathSet_Free(pathSet: *mut nfdpathset_t);
+    pub fn NFD_Free(ptr: *mut std::os::raw::c_void);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,9 +244,12 @@ pub fn open_dialog(
 
                     Ok(Response::OkayMultiple(res))
                 } else {
-                    Ok(Response::Okay(PathBuf::from(
-                        CStr::from_ptr(out_path).to_string_lossy().into_owned(),
-                    )))
+                    let path =
+                        PathBuf::from(CStr::from_ptr(out_path).to_string_lossy().into_owned());
+
+                    NFD_Free(out_path as *mut _);
+
+                    Ok(Response::Okay(path))
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 pub mod error;
 pub mod ffi;
 
-use error::NFDError;
+use error::NfdError;
 use ffi::*;
 use std::{
     ffi::{CStr, CString},
@@ -149,7 +149,7 @@ pub fn dialog_save<'a>() -> DialogBuilder<'a> {
     DialogBuilder::new(DialogType::SaveFile)
 }
 
-pub type Result<T> = std::result::Result<T, NFDError>;
+pub type Result<T> = std::result::Result<T, NfdError>;
 
 /// Open single file dialog
 pub fn open_file_dialog(
@@ -200,7 +200,7 @@ pub fn open_dialog(
     let default_path_ptr = match default_path {
         Some(dp_str) => {
             default_path_cstring = CString::new(dp_str.to_str().ok_or_else(|| {
-                NFDError::Error("unable to convert default path to utf-8".to_owned())
+                NfdError::Error("unable to convert default path to utf-8".to_owned())
             })?)?;
             default_path_cstring.as_ptr()
         }
@@ -229,7 +229,7 @@ pub fn open_dialog(
         };
 
         match result {
-            nfdresult_t::NFD_OKAY => {
+            nfdresult_t::Okay => {
                 if dialog_type == DialogType::MultipleFiles {
                     let count = NFD_PathSet_GetCount(&out_multiple);
                     let mut res = Vec::with_capacity(count);
@@ -253,8 +253,8 @@ pub fn open_dialog(
                 }
             }
 
-            nfdresult_t::NFD_CANCEL => Ok(Response::Cancel),
-            nfdresult_t::NFD_ERROR => Err(NFDError::Error(
+            nfdresult_t::Cancel => Ok(Response::Cancel),
+            nfdresult_t::Error => Err(NfdError::Error(
                 CStr::from_ptr(NFD_GetError())
                     .to_string_lossy()
                     .into_owned(),


### PR DESCRIPTION
This PR updates nfd to the devel branch to take advantage of some changes that haven't hit master yet. When updating, I also noticed that there was a memory leak where the path was not being freed, so fixed that.

This also fixes all the clippy lints as of 1.51.0.